### PR TITLE
Bnx 136 SIM connection reset durin insert/remove

### DIFF
--- a/modules/luci-base/root/usr/share/rpcd/acl.d/luci-base.json
+++ b/modules/luci-base/root/usr/share/rpcd/acl.d/luci-base.json
@@ -94,7 +94,8 @@
 				"/tmp/firmware.bin": [ "write" ],
 				"/tmp/upload.ipk": [ "write" ],
 				"/usr/sbin/iptables -Z": [ "exec" ],
-				"/usr/sbin/ip6tables -Z": [ "exec" ]
+				"/usr/sbin/ip6tables -Z": [ "exec" ],
+				"/usr/bin/sim-pci-reset": [ "exec" ]
 			},
 			"ubus": {
 				"file": [ "write", "remove", "exec" ],

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
@@ -977,6 +977,9 @@ return L.view.extend({
 
 					if (dsc.getAttribute('reconnect') == '') {
 						dsc.setAttribute('reconnect', '1');
+						tasks.push(fs.exec_direct('/usr/bin/sim-pci-reset', [section_ids[i]]).catch(function(e) {
+							ui.addNotification(null, E('p', e.message));
+						}));
 						tasks.push(fs.exec('/sbin/ifup', [section_ids[i]]).catch(function(e) {
 							ui.addNotification(null, E('p', e.message));
 						}));


### PR DESCRIPTION
SIM connection is not working when we insert/remove sim after device bootsup.
Need to reset SIM pci from interface restart button so it will detect sim and able to make connection.